### PR TITLE
change html class of intro paragraph to jumble contents correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,19 +16,19 @@
       <div class="well" id="instruct">
         <blockquote>
           <h1 id="title1">To Make A Dadist Poem</h1>
-          <p id="paragraph"
-            "Take a newspaper. </br>
-            Take some scissors. </br>
-            Choose from this paper an article the length you want to make your poem. </br>
-            Cut out the article. </br>
-            Next carefully cut out each of the words that make up this article and put them all in a bag. </br>
-            Shake gently. </br>
-            Next take out each cutting one after the other. </br>
-            Copy conscientiously in the order in which they left the bag. </br>
-            The poem will resemble you. </br>
-            And there you are--an infinitely original author of charming sensibility, even though
-            unappreciated by the vulgar herd." </br>
-          </p>
+          <PRE id="paragraph">
+  "Take a newspaper.
+  Take some scissors.
+  Choose from this paper an article the length you want to make your poem.
+  Cut out the article.
+  Next carefully cut out each of the words that make up this article and put them all in a bag.
+  Shake gently.
+  Next take out each cutting one after the other.
+  Copy conscientiously in the order in which they left the bag.
+  The poem will resemble you.
+  And there you are--an infinitely original author of charming sensibility, even though
+  unappreciated by the vulgar herd."
+          </PRE>
           <footer>Tristan Tzara</footer>
         </blockquote>
         <div class="row" id="getStartedRow">

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -28,22 +28,20 @@ $(document).ready(function() {
     var titleArray = title1.split(" ");
     var jumbledTitle = shuffle(titleArray);
     $(".jumbledTitle").text(jumbledTitle);
-    //debugger;
+
 
     var instructions = $("#paragraph").html();
     var instructArray = instructions.split(" ");
     var newInstructArray = [];
-    //debugger;
     console.log(instructions);
     console.log(instructArray);
 
     instructArray.forEach(function(i) {
-      //BUG!!!
-        if (i != "<br>↵") {
-          newInstructArray.push(i)
+      if (i != "<br>↵") {
+        newInstructArray.push(i)
         }
       });
-    //console.log(newInstructArray);
+
 
     var jumbledInstruct = shuffle(newInstructArray);
     $("#jumbledInstruct").text(jumbledInstruct);


### PR DESCRIPTION
I change the intro from a <p> element to <PRE> this allows us to not use any br elements which were getting displayed on the page. The PRE tag has some default styling so we will need to overide it in css to get it to look how it was before. Let me know if you would like me to do that or if it will be assigned to someone else.